### PR TITLE
disable the addCorrectTest test

### DIFF
--- a/src/test/java/me/rubaiya/CalculatorTest.java
+++ b/src/test/java/me/rubaiya/CalculatorTest.java
@@ -1,6 +1,7 @@
 package me.rubaiya;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -19,6 +20,7 @@ public class CalculatorTest {
     }
 
     @Test
+    @Disabled
     void addCorrectTest() {
         assertEquals(30, calculator.add(10, 20), "All is well.");
     }

--- a/src/test/java/me/rubaiya/CalculatorTest.java
+++ b/src/test/java/me/rubaiya/CalculatorTest.java
@@ -20,7 +20,6 @@ public class CalculatorTest {
     }
 
     @Test
-    @Disabled
     void addCorrectTest() {
         assertEquals(30, calculator.add(10, 20), "All is well.");
     }
@@ -31,6 +30,7 @@ public class CalculatorTest {
     }
 
     @Test
+    @Disabled
     void addTypeIncorrectTest() {
         assertNotEquals(true, calculator.add(10, 20),"You're just not my type.");
     }


### PR DESCRIPTION
In JUnit4, @Ignored annotation was used to ignore a test. Whereas, from JUnit5, the @Disabled annotation is being used to ignore a particular test.